### PR TITLE
Fix #12: Force the server and client of Node.js Com to use IPv4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        nodejsversion: ["15"]
         scalaversion: ["2.11.12", "2.12.11", "2.13.2"]
         project: ["scalajs-js-envs", "scalajs-js-envs-test-kit", "scalajs-env-nodejs"]
+        include:
+          - nodejsversion: "16"
+            scalaversion: "2.12.11"
+            project: "scalajs-env-nodejs"
+          - nodejsversion: "17"
+            scalaversion: "2.12.11"
+            project: "scalajs-env-nodejs"
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: "adopt@1.8"
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "${{ matrix.nodejsversion }}"
       - uses: coursier/cache-action@v5
       - name: Test
         run: sbt "++${{ matrix.scalaversion }}" ${{ matrix.project }}/test

--- a/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/ComSupport.scala
+++ b/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/ComSupport.scala
@@ -209,7 +209,7 @@ object ComRun {
   def start(config: RunConfig, onMessage: String => Unit)(startRun: Path => JSRun): JSComRun = {
     try {
       val serverSocket =
-        new ServerSocket(0, 0, InetAddress.getByName(null)) // Loopback address
+        new ServerSocket(0, 0, InetAddress.getByName("127.0.0.1")) // IPv4 loopback address
 
       val run = startRun(setupFile(serverSocket.getLocalPort))
 
@@ -248,7 +248,7 @@ object ComRun {
         s"""
            |(function() {
            |  // The socket for communication
-           |  var socket = require('net').connect($port);
+           |  var socket = require('net').connect($port, '127.0.0.1'); // IPv4 loopback address
            |
            |  // Buffers received data
            |  var inBuffer = Buffer.alloc(0);


### PR DESCRIPTION
Node.js 17 switched from resolving host names to IPv4 by default to resolving to the order given by the OS. This was an intended change done in nodejs/node#39987, which nevertheless caused issues in downstream projects, as reported in nodejs/node#40537.

scalajs-env-nodejs hit that issue, as the JVM server opened on IPv4 by default (apparently this is what the JVM does), but the client tried to connect via IPv6 with Node.js 17. We fix the issue by forcing the use of IPv4 in the Node.js client, as well as on the JVM server for good measure.