### PR TITLE
Bump the version to 1.4.0-SNAPSHOT.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val previousVersion: Option[String] = Some("1.3.0")
 val newScalaBinaryVersionsInThisRelease: Set[String] = Set()
 
 inThisBuild(Def.settings(
-  version := "1.3.1-SNAPSHOT",
+  version := "1.4.0-SNAPSHOT",
   organization := "org.scala-js",
   scalaVersion := "2.12.11",
   crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.2"),


### PR DESCRIPTION
To account for the new feature in f8e9533cf4b29739676fe9593cacb8309ea7bc62.