### PR TITLE
Support WasmtimeEnv and Com support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ val newScalaBinaryVersionsInThisRelease: Set[String] = Set.empty
 
 inThisBuild(Def.settings(
   organization := "org.scala-js",
+  version := "1.4.0-wasmcomponent-SNAPSHOT",
   scalaVersion := "2.12.11",
   crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.2", "3.3.7"),
   scalacOptions ++= Seq(
@@ -99,6 +100,7 @@ lazy val root = project
     `scalajs-js-envs`,
     `scalajs-js-envs-test-kit`,
     `scalajs-env-nodejs`,
+    `scalajs-env-wasmtime`,
   )
   .settings(
     publish / skip := true,
@@ -136,3 +138,11 @@ lazy val `scalajs-env-nodejs` = project
     ),
   )
   .dependsOn(`scalajs-js-envs`, `scalajs-js-envs-test-kit` % "test")
+
+lazy val `scalajs-env-wasmtime` = project
+  .in(file("wasmtime"))
+  .settings(
+    commonSettings,
+    name := "scalajs-env-wasmtime",
+  )
+  .dependsOn(`scalajs-js-envs`)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,7 @@
 import com.typesafe.tools.mima.core.{Problem, ProblemFilters}
+import org.scalajs.linker.interface.ModuleKind
+import org.scalajs.sbtplugin.ScalaJSPlugin
+import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 
 val previousVersion: Option[String] = Some("1.5.0")
 val newScalaBinaryVersionsInThisRelease: Set[String] = Set.empty
@@ -139,10 +142,56 @@ lazy val `scalajs-env-nodejs` = project
   )
   .dependsOn(`scalajs-js-envs`, `scalajs-js-envs-test-kit` % "test")
 
+// Produces the Wasm component binary that is an adapter for talking to sbt (JVM)
+// over WASI sockets. The generated binary is published as a resource of the
+// `scalajs-env-wasmtime` project, and is composed with the component under test
+// during test execution.
+lazy val `wasmtime-test-rpc-adapter` = project
+  .in(file("wasmtime-test-rpc-adapter"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    name := "wasmtime-test-rpc-adapter",
+    commonSettings,
+    publish / skip := true,
+    scalaVersion := "2.12.11",
+    crossScalaVersions := Seq("2.12.11"),
+    scalaJSUseMainModuleInitializer := false,
+    scalaJSWitDirectory := baseDirectory.value / "wit",
+    scalaJSWitWorld := Some("test-rpc-adapter"),
+    scalaJSLinkerConfig ~= { config =>
+      val witDir = file("wasmtime-test-rpc-adapter/wit").getAbsolutePath
+      config
+        .withExperimentalUseWebAssembly(true)
+        .withWasmFeatures(_.withWitDirectory(Some(witDir)))
+        .withWasmFeatures(_.withWitWorld(Some("test-rpc-adapter")))
+        .withModuleKind(ModuleKind.WasmComponent)
+    },
+    Compile / fastLinkJS / scalaJSLinkerOutputDirectory := target.value / "adapter-fastopt",
+  )
+
 lazy val `scalajs-env-wasmtime` = project
   .in(file("wasmtime"))
   .settings(
     commonSettings,
     name := "scalajs-env-wasmtime",
+    Compile / resourceGenerators += Def.task {
+      (`wasmtime-test-rpc-adapter` / Compile / fastLinkJS).value
+
+      val fastSource =
+        (`wasmtime-test-rpc-adapter` / Compile / fastLinkJS / scalaJSLinkerOutputDirectory).value / "main.wasm"
+
+      // This must match with `AdapterResourcePath` in `wasmtime/ComSupport.scala`
+      val targetDir =
+        (Compile / resourceManaged).value /
+          "org" / "scalajs" / "jsenv" / "wasmtime" / "test-rpc"
+      val defaultTarget = targetDir / "adapter.wasm"
+      val fastTarget = targetDir / "adapter-fastopt.wasm"
+
+      IO.createDirectory(targetDir)
+      IO.copyFile(fastSource, fastTarget)
+      IO.copyFile(fastSource, defaultTarget)
+
+      Seq(defaultTarget, fastTarget)
+    }.taskValue,
   )
   .dependsOn(`scalajs-js-envs`)

--- a/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
@@ -40,6 +40,9 @@ object Input {
 
   /** The file is to be loaded as a CommonJS module. */
   final case class CommonJSModule(module: Path) extends Input
+
+  /** The file is a WebAssembly component binary. */
+  final case class WasmComponent(component: Path) extends Input
 }
 
 class UnsupportedInputException(msg: String, cause: Throwable)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,6 @@
+resolvers += "Sonatype Central Snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"
+
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
+addSbtPlugin("io.github.scala-wasm" % "sbt-scalajs" % "1.20.2-wasm.2-SNAPSHOT")

--- a/wasmtime-test-rpc-adapter/src/main/scala/org/scalajs/jsenv/wasmtime/adapter/TestRpcAdapter.scala
+++ b/wasmtime-test-rpc-adapter/src/main/scala/org/scalajs/jsenv/wasmtime/adapter/TestRpcAdapter.scala
@@ -1,0 +1,227 @@
+/*
+ * Scala.js JS Envs (https://github.com/scala-js/scala-js-js-envs)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.jsenv.wasmtime.adapter
+
+import java.nio.ByteBuffer
+import java.util.Optional
+
+import scala.scalajs.wasi.cli.environment
+import scala.scalajs.wasi.io.streams.{InputStream, OutputStream, StreamError}
+import scala.scalajs.wasi.sockets.instance_network
+import scala.scalajs.wasi.sockets.network
+import scala.scalajs.wasi.sockets.tcp
+import scala.scalajs.wasi.sockets.tcp_create_socket
+import scala.scalajs.wit.annotation._
+import scala.scalajs.wit.{Err, Ok, Tuple2}
+import scala.scalajs.wit.unsigned.{UByte, UShort}
+
+@WitExportInterface
+trait Rpc {
+  @WitExport("scalajs:test-rpc/rpc", "init")
+  def init(): Unit
+
+  @WitExport("scalajs:test-rpc/rpc", "send")
+  def send(msg: String): Unit
+
+  @WitExport("scalajs:test-rpc/rpc", "poll")
+  def poll(): Optional[String]
+}
+
+private object TestRpcTransport {
+  private object Protocol {
+    final val RpcHostEnv = "SCALAJS_TEST_RPC_HOST"
+    final val RpcPortEnv = "SCALAJS_TEST_RPC_PORT"
+  }
+
+  // TODO(nit): initialize with null instead of optional
+  private[this] var inputStream: Option[InputStream] = None
+  private[this] var outputStream: Option[OutputStream] = None
+  private[this] val envVars: Map[String, String] =
+    environment.getEnvironment().iterator.map(e => e._1 -> e._2).toMap
+
+  def init(): Unit = {
+    if (inputStream.isEmpty || outputStream.isEmpty) {
+      val Array(a, b, c, d) = envVars.get(Protocol.RpcHostEnv).get.split("\\.")
+      val port = envVars.get(Protocol.RpcPortEnv).get.toInt.toShort.asInstanceOf[UShort]
+
+      val networkHandle = instance_network.instanceNetwork()
+      try {
+        val socket =
+          tcp_create_socket.createTcpSocket(network.IpAddressFamily.Ipv4) match {
+            case ok: Ok[tcp.TcpSocket] =>
+              ok.value
+            case err: Err[network.ErrorCode] =>
+              throw new IllegalStateException(s"create-tcp-socket failed: ${err.value}")
+        }
+
+        val remoteAddress = network.IpSocketAddress.Ipv4(
+            network.Ipv4SocketAddress(port, (
+              a.toByte.asInstanceOf[UByte],
+              b.toByte.asInstanceOf[UByte],
+              c.toByte.asInstanceOf[UByte],
+              d.toByte.asInstanceOf[UByte]
+            )))
+
+        socket.startConnect(networkHandle, remoteAddress) match {
+          case _: Ok[Unit] =>
+          case err: Err[network.ErrorCode] =>
+            throw new IllegalStateException(s"start-connect failed: ${err.value}")
+        }
+
+        val streams = finishConnect(socket)
+        val in = streams._1
+        val out = streams._2
+        inputStream = Some(in)
+        outputStream = Some(out)
+      } finally {
+        networkHandle.close()
+      }
+    }
+  }
+
+  def send(msg: String): Unit = {
+    val out = currentOutputStream()
+    val payload = ByteBuffer.allocate(4 + msg.length * 2)
+    payload.putInt(msg.length)
+    var i = 0
+    while (i < msg.length) {
+      payload.putChar(msg.charAt(i))
+      i += 1
+    }
+
+    writeAll(out, payload.array())
+  }
+
+  def poll(): Optional[String] = {
+    val in = currentInputStream()
+    val message: Optional[String] =
+      readNBytes(in, 4) match {
+        case None =>
+          Optional.empty()
+        case Some(headerBytes) =>
+          val msgLen = ByteBuffer.wrap(headerBytes).getInt()
+          val payload = readNBytes(in, msgLen * 2).getOrElse {
+            throw new IllegalStateException("Unexpected EOF while reading framed payload")
+          }
+
+          val chars = new Array[Char](msgLen)
+          val payloadBuffer = ByteBuffer.wrap(payload)
+          var i = 0
+          while (i < msgLen) {
+            chars(i) = payloadBuffer.getChar()
+            i += 1
+          }
+
+          Optional.of(String.valueOf(chars))
+      }
+
+    if (message.isEmpty)
+      closeState()
+    message
+  }
+
+  private def currentInputStream(): InputStream =
+    inputStream.getOrElse(throw new IllegalStateException("RPC input stream is not initialized"))
+
+  private def currentOutputStream(): OutputStream =
+    outputStream.getOrElse(throw new IllegalStateException("RPC output stream is not initialized"))
+
+  private def finishConnect(socket: tcp.TcpSocket): Tuple2[InputStream, OutputStream] = {
+    while (true) {
+      socket.finishConnect() match {
+        case ok: Ok[Tuple2[InputStream, OutputStream]] =>
+          return ok.value
+
+        // Returns would-block if it's in progress
+        // https://github.com/WebAssembly/WASI/blob/50b674e4349aca006cccd699c1a5b6925cae6e88/proposals/sockets/README.md?plain=1#L71-L125
+        case err: Err[network.ErrorCode] if err.value == network.ErrorCode.WouldBlock =>
+          val pollable = socket.subscribe()
+          try pollable.block()
+          finally pollable.close()
+
+        case err: Err[network.ErrorCode] =>
+          throw new IllegalStateException(s"finish connect failed: ${err.value}")
+      }
+    }
+
+    throw new AssertionError("unreachable")
+  }
+
+  private def readNBytes(in: InputStream, len: Int): Option[Array[Byte]] = {
+    val result = new Array[Byte](len)
+    var offset = 0
+
+    while (offset < len) {
+      val chunk = in.blockingRead((len - offset).toLong) match {
+        case ok: Ok[Array[Byte]] =>
+          ok.value
+        case err: Err[StreamError] if err.value == StreamError.Closed =>
+          if (offset == 0) return None
+          else throw new IllegalStateException(s"Unexpected EOF after $offset/$len bytes")
+        case err: Err[_] =>
+          err.value match {
+            case last: StreamError.LastOperationFailed =>
+              throw new IllegalStateException(last.value.toDebugString())
+          }
+      }
+
+      java.lang.System.arraycopy(chunk, 0, result, offset, chunk.length)
+      offset += chunk.length
+    }
+
+    Some(result)
+  }
+
+  private def writeAll(out: OutputStream, bytes: Array[Byte]): Unit = {
+    var offset = 0
+    // blocking-write-and-flush writes up to 4096 bytes
+    while (offset < bytes.length) {
+      val end = Math.min(offset + 4096, bytes.length)
+      val chunk = java.util.Arrays.copyOfRange(bytes, offset, end)
+
+      out.blockingWriteAndFlush(chunk) match {
+        case _: Ok[Unit] =>
+        case err: Err[StreamError] if err.value == StreamError.Closed =>
+          throw new IllegalStateException("test RPC socket closed while writing")
+        case err: Err[_] =>
+          err.value match {
+            case last: StreamError.LastOperationFailed =>
+              throw new IllegalStateException(last.value.toDebugString())
+          }
+      }
+
+      offset = end
+    }
+  }
+
+  private def closeState(): Unit = {
+    try inputStream.foreach(_.close())
+    finally inputStream = None
+
+    try outputStream.foreach(_.close())
+    finally outputStream = None
+  }
+
+}
+
+@WitImplementation
+object TestRpcAdapter extends Rpc {
+  override def init(): Unit =
+    TestRpcTransport.init()
+
+  override def send(msg: String): Unit =
+    TestRpcTransport.send(msg)
+
+  override def poll(): Optional[String] =
+    TestRpcTransport.poll()
+}

--- a/wasmtime-test-rpc-adapter/wit/deps/scalajs-test-rpc/package.wit
+++ b/wasmtime-test-rpc-adapter/wit/deps/scalajs-test-rpc/package.wit
@@ -1,0 +1,7 @@
+package scalajs:test-rpc;
+
+interface rpc {
+  init: func();
+  send: func(msg: string);
+  poll: func() -> option<string>;
+}

--- a/wasmtime-test-rpc-adapter/wit/world.wit
+++ b/wasmtime-test-rpc-adapter/wit/world.wit
@@ -1,0 +1,5 @@
+package scalajs:test-rpc-adapter;
+
+world test-rpc-adapter {
+  export scalajs:test-rpc/rpc;
+}

--- a/wasmtime/src/main/scala/org/scalajs/jsenv/wasmtime/ComSupport.scala
+++ b/wasmtime/src/main/scala/org/scalajs/jsenv/wasmtime/ComSupport.scala
@@ -1,0 +1,297 @@
+/*
+ * Scala.js JS Envs (https://github.com/scala-js/scala-js-js-envs)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.jsenv.wasmtime
+
+import java.io._
+import java.net._
+import java.nio.file.{Files, Path, StandardCopyOption}
+
+import scala.concurrent._
+import scala.sys.process._
+import scala.util.{Failure, Success}
+import scala.util.control.NonFatal
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import org.scalajs.jsenv._
+
+private final class ComRun(run: JSRun, handleMessage: String => Unit,
+    serverSocket: ServerSocket) extends JSComRun {
+  import ComRun._
+
+  /** Promise that completes once the receiver thread is completed. */
+  private[this] val promise = Promise[Unit]()
+
+  @volatile
+  private[this] var state: State = AwaitingConnection(Nil)
+
+  // If the run completes, make sure we also complete.
+  run.future.onComplete {
+    case Failure(t) => forceClose(t)
+    case Success(_) => onJSTerminated()
+  }
+
+  private[this] val receiver = new Thread {
+    setName("ComRun receiver")
+
+    override def run(): Unit = {
+      try {
+        try {
+          /* We need to await the connection unconditionally. Otherwise the JS end
+           * might try to connect indefinitely.
+           */
+          awaitConnection()
+
+          while (state != Closing) {
+            state match {
+              case s: AwaitingConnection =>
+                throw new IllegalStateException(s"Unexpected state: $s")
+
+              case Closing =>
+                /* We can end up here if there is a race between the two read to
+                 * state. Do nothing, loop will terminate.
+                 */
+
+              case Connected(_, _, js2jvm) =>
+                try {
+                  val len = js2jvm.readInt()
+                  if (len < 0)
+                    throw new IllegalArgumentException(s"negative frame length: $len")
+
+                  val chars = Array.fill(len)(js2jvm.readChar())
+                  handleMessage(String.valueOf(chars))
+                } catch {
+                  case _: EOFException =>
+                    // JS end terminated gracefully. Close.
+                    close()
+                }
+            }
+          }
+        } catch {
+          case _: IOException if state == Closing =>
+            // We got interrupted by a graceful close.
+            // This is OK.
+        }
+
+        /* Everything got closed. We wait for the run to terminate.
+         * We need to wait in order to make sure that closing the
+         * underlying run does not fail it.
+         */
+        ComRun.this.run.future.foreach { _ =>
+          ComRun.this.run.close()
+          promise.trySuccess(())
+        }
+      } catch {
+        case t: Throwable => handleThrowable(t)
+      }
+    }
+  }
+
+  receiver.start()
+
+  def future: Future[Unit] = promise.future
+
+  def send(msg: String): Unit = synchronized {
+    state match {
+      case AwaitingConnection(msgs) =>
+        state = AwaitingConnection(msg :: msgs)
+
+      case Connected(_, jvm2js, _) =>
+        try {
+          writeMsg(jvm2js, msg)
+          jvm2js.flush()
+        } catch {
+          case t: Throwable => handleThrowable(t)
+        }
+
+      case Closing => // ignore msg.
+    }
+  }
+
+  def close(): Unit = synchronized {
+    val oldState = state
+
+    // Signal receiver thread that it is OK if socket read fails.
+    state = Closing
+
+    oldState match {
+      case c: Connected =>
+        // Interrupts the receiver thread and signals the VM to terminate.
+        closeAll(c)
+
+      case Closing | _: AwaitingConnection =>
+    }
+  }
+
+  private def onJSTerminated() = {
+    close()
+
+    /* Interrupt receiver if we are still waiting for connection.
+     * Should only be relevant if we are still awaiting the connection.
+     * Note: We cannot do this in close(), otherwise if the JVM side closes
+     * before the JS side connected, the JS VM will fail instead of terminate
+     * normally.
+     */
+    serverSocket.close()
+  }
+
+  private def forceClose(cause: Throwable) = {
+    promise.tryFailure(cause)
+    close()
+    run.close()
+    serverSocket.close()
+  }
+
+  private def handleThrowable(cause: Throwable) = {
+    forceClose(cause)
+    if (!NonFatal(cause))
+      throw cause
+  }
+
+  private def awaitConnection(): Unit = {
+    var comSocket: Socket = null
+    var jvm2js: DataOutputStream = null
+    var js2jvm: DataInputStream = null
+
+    try {
+      comSocket = serverSocket.accept()
+      serverSocket.close()
+      jvm2js = new DataOutputStream(
+          new BufferedOutputStream(comSocket.getOutputStream()))
+      js2jvm = new DataInputStream(
+          new BufferedInputStream(comSocket.getInputStream()))
+
+      onConnected(Connected(comSocket, jvm2js, js2jvm))
+    } catch {
+      case t: Throwable =>
+        closeAll(comSocket, jvm2js, js2jvm)
+        throw t
+    }
+  }
+
+  private def onConnected(c: Connected): Unit = synchronized {
+    state match {
+      case AwaitingConnection(msgs) =>
+        msgs.reverse.foreach(writeMsg(c.jvm2js, _))
+        c.jvm2js.flush()
+        state = c
+
+      case _: Connected =>
+        throw new IllegalStateException(s"Unexpected state: $state")
+
+      case Closing =>
+        closeAll(c)
+    }
+  }
+
+}
+
+object ComRun {
+  private final val RpcHostEnv = "SCALAJS_TEST_RPC_HOST"
+  private final val RpcPortEnv = "SCALAJS_TEST_RPC_PORT"
+
+  def start(wasmPath: Path, config: RunConfig, onMessage: String => Unit)(
+      startRun: ((Path, Map[String, String])) => JSRun): JSComRun = {
+    try {
+      // Compose with adapter component generated by `wasmtime-test-rpc-adapter`
+      // that reads socket address through env variables.
+      val serverSocket =
+        new ServerSocket(0, 0, InetAddress.getByName("127.0.0.1")) // IPv4 loopback address
+
+      try {
+        val env = Map(
+            RpcHostEnv -> "127.0.0.1",
+            RpcPortEnv -> serverSocket.getLocalPort.toString)
+
+        val composedWasmPath = ComponentSupport.composeWithAdapter(wasmPath)
+        val run = startRun((composedWasmPath, env))
+        new ComRun(run, onMessage, serverSocket)
+      } catch {
+        case NonFatal(t) =>
+          closeAll(serverSocket)
+          JSComRun.failed(t)
+      }
+    } catch {
+      case NonFatal(t) => JSComRun.failed(t)
+    }
+  }
+
+  private def closeAll(c: Closeable*): Unit =
+    c.withFilter(_ != null).foreach(_.close())
+
+  private def closeAll(c: Connected): Unit =
+    closeAll(c.comSocket, c.jvm2js, c.js2jvm)
+
+  private sealed trait State
+
+  private final case class AwaitingConnection(
+      sendQueue: List[String]) extends State
+
+  private final case class Connected(
+      comSocket: Socket,
+      jvm2js: DataOutputStream,
+      js2jvm: DataInputStream) extends State
+
+  private case object Closing extends State
+
+  private def writeMsg(out: DataOutputStream, msg: String): Unit = {
+    out.writeInt(msg.length)
+    out.writeChars(msg)
+  }
+
+  private object ComponentSupport {
+    private final val AdapterResourcePath =
+      "/org/scalajs/jsenv/wasmtime/test-rpc/adapter.wasm"
+
+    private lazy val adapterComponentPath: Path = {
+      val path = Files.createTempFile("scalajs-wasmtime-test-rpc-adapter-", ".wasm")
+      val in = getClass.getResourceAsStream(AdapterResourcePath)
+      if (in == null) {
+        throw new IllegalStateException(
+            s"Missing Wasmtime test RPC resource: $AdapterResourcePath")
+      }
+      try {
+        Files.copy(in, path, StandardCopyOption.REPLACE_EXISTING)
+      } finally {
+        in.close()
+      }
+      path.toFile.deleteOnExit()
+      path
+    }
+
+    def composeWithAdapter(component: Path): Path = {
+      val composed = Files.createTempFile("scalajs-wasmtime-composed-", ".wasm")
+      composed.toFile.deleteOnExit()
+      val cmd = Seq(
+          "wac", "plug",
+          "--plug", adapterComponentPath.toAbsolutePath.normalize.toString,
+          component.toAbsolutePath.normalize.toString,
+          "-o", composed.toAbsolutePath.normalize.toString
+      )
+
+      runCommand(cmd, "wac plug")
+      composed
+    }
+
+    private def runCommand(cmd: Seq[String], desc: String): Unit = {
+      val err = new StringBuilder
+      val exit = Process(cmd).!(ProcessLogger(_ => (), line => err.append(line).append('\n')))
+      if (exit != 0) {
+        throw new IllegalStateException(
+            s"$desc failed with exit code $exit\n" +
+            s"command: ${cmd.mkString(" ")}\n" +
+            err.toString)
+      }
+    }
+  }
+}

--- a/wasmtime/src/main/scala/org/scalajs/jsenv/wasmtime/WasmtimeEnv.scala
+++ b/wasmtime/src/main/scala/org/scalajs/jsenv/wasmtime/WasmtimeEnv.scala
@@ -29,8 +29,12 @@ final class WasmtimeEnv(config: WasmtimeEnv.Config) extends JSEnv {
 
   def startWithCom(input: Seq[Input], runConfig: RunConfig,
       onMessage: String => Unit): JSComRun = {
-    JSComRun.failed(new UnsupportedOperationException(
-        "WasmtimeEnv does not support startWithCom yet."))
+    WasmtimeEnv.validator.validate(runConfig)
+    val wasmPath = validateInput(input)
+    ComRun.start(wasmPath, runConfig, onMessage) { case (comWasmPath, env) =>
+      val comRunConfig = runConfig.withEnv(env ++ runConfig.env)
+      internalStart(comWasmPath, comRunConfig)
+    }
   }
 
   private def validateInput(input: Seq[Input]): Path =

--- a/wasmtime/src/main/scala/org/scalajs/jsenv/wasmtime/WasmtimeEnv.scala
+++ b/wasmtime/src/main/scala/org/scalajs/jsenv/wasmtime/WasmtimeEnv.scala
@@ -1,0 +1,105 @@
+/*
+ * Scala.js JS Envs (https://github.com/scala-js/scala-js-js-envs)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.jsenv.wasmtime
+
+import java.nio.file.Path
+
+import org.scalajs.jsenv._
+
+final class WasmtimeEnv(config: WasmtimeEnv.Config) extends JSEnv {
+  def this() = this(WasmtimeEnv.Config())
+
+  val name: String = "wasmtime"
+
+  def start(input: Seq[Input], runConfig: RunConfig): JSRun = {
+    WasmtimeEnv.validator.validate(runConfig)
+    val wasmPath = validateInput(input)
+    internalStart(wasmPath, runConfig)
+  }
+
+  def startWithCom(input: Seq[Input], runConfig: RunConfig,
+      onMessage: String => Unit): JSComRun = {
+    JSComRun.failed(new UnsupportedOperationException(
+        "WasmtimeEnv does not support startWithCom yet."))
+  }
+
+  private def validateInput(input: Seq[Input]): Path =
+    WasmtimeEnv.resolveInput(input)
+
+  private def internalStart(wasmPath: Path, runConfig: RunConfig): JSRun = {
+    val command = baseCommand(wasmPath)
+    val externalConfig = ExternalJSRun.Config()
+      .withEnv(config.env)
+      .withRunConfig(runConfig)
+
+    ExternalJSRun.start(command, externalConfig)(_.close())
+  }
+
+  private def baseCommand(wasmPath: Path): List[String] =
+    config.executable :: (config.args :+ wasmPath.toAbsolutePath.normalize.toString)
+}
+
+object WasmtimeEnv {
+  private lazy val validator = ExternalJSRun.supports(RunConfig.Validator())
+
+  private[wasmtime] def resolveInput(input: Seq[Input]): Path = {
+    val wasmComponents = input.collect { case wasm: Input.WasmComponent => wasm.component }
+
+    if (wasmComponents.size != input.size) {
+      throw new UnsupportedInputException(
+          "WasmtimeEnv only supports Input.WasmComponent. " +
+          "Do not mix with Script/ESModule/CommonJSModule inputs.")
+    }
+    if (wasmComponents.size != 1) {
+      throw new UnsupportedInputException(
+          s"WasmtimeEnv requires exactly one Input.WasmComponent, got ${wasmComponents.size}.")
+    }
+
+    wasmComponents.head
+  }
+
+  final class Config private (
+      val executable: String,
+      val args: List[String],
+      val env: Map[String, String]
+  ) {
+    private def this() = {
+      this(
+          executable = "wasmtime",
+          args = List("-W", "gc,function-references,exceptions"),
+          env = Map.empty
+      )
+    }
+
+    def withExecutable(executable: String): Config =
+      copy(executable = executable)
+
+    def withArgs(args: List[String]): Config =
+      copy(args = args)
+
+    def withEnv(env: Map[String, String]): Config =
+      copy(env = env)
+
+    private def copy(
+        executable: String = executable,
+        args: List[String] = args,
+        env: Map[String, String] = env
+    ): Config = {
+      new Config(executable, args, env)
+    }
+  }
+
+  object Config {
+    def apply(): Config = new Config()
+  }
+}


### PR DESCRIPTION
First commit adds `Input.WasmComponent` to represent WebAssembly component binaries,
and `org.scalajs.jsenv.wasmtime.WasmtimeEnv` implementation to run `Input.WasmComponent` via external `wasmtime` command.

---

Second commit adds COM support for running tests against Component Model binaries in WasmtimeEnv.

For Wasm Component, JVM and the Wasm under test communicates through `wasmtime-test-rpc-adapter`, a Wasm component adapter that uses WASI sockets to talk to the socket opened by sbt.

The adapter component exports the following WIT interface:

```wit
package scalajs:test-rpc;

interface rpc {
  init: func();
  send: func(msg: string);
  poll: func() -> option<string>;
}
```

The generated Wasm component binary is published as a resource of
`scalajs-env-wasmtime`, and will be composed with the component under test using `wac` before execution.