### PR TITLE
Open up `Input` for custom extensions.

### DIFF
--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/RunTests.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/RunTests.scala
@@ -26,6 +26,8 @@ import org.scalajs.jsenv.test.kit.{TestKit, Run}
 
 private[test] class RunTests(config: JSEnvSuiteConfig, withCom: Boolean,
     defaultInputKind: TestKit.InputKind) {
+  import RunTests._
+
   private val kit = new TestKit(config.jsEnv, config.awaitTimeout, defaultInputKind)
 
   private def withRun(input: Seq[Input])(body: Run => Unit) = {
@@ -181,4 +183,14 @@ private[test] class RunTests(config: JSEnvSuiteConfig, withCom: Boolean,
     val cfg = RunConfig().withEternallyUnsupportedOption(true)
     withRun("", cfg)(identity)
   }
+
+  @Test(expected = classOf[UnsupportedInputException])
+  def ensureValidateInput: Unit = {
+    val input = EternallyUnsupportedInput()
+    withRun(Seq(input))(identity)
+  }
+}
+
+private[test] object RunTests {
+  final case class EternallyUnsupportedInput() extends Input
 }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
@@ -19,11 +19,13 @@ import java.nio.file.Path
  *  Implementors of a [[JSEnv]] are expected to pattern match on this input
  *  type and handle the ones they support.
  *
- *  Note that this type is not sealed, so future versions of Scala.js may add
- *  additional input types. Older [[JSEnv]]s are expected to fail in this case
- *  with an [[UnsupportedInputException]].
+ *  Note that this type is not sealed, so future versions of Scala.js, as well
+ *  as third-party libraries, may add additional input types.
+ *
+ *  [[JSEnv]]s are expected to fail with an [[UnsupportedInputException]] on
+ *  `Input` types that they do not handle.
  */
-abstract class Input private ()
+abstract class Input
 
 object Input {
   /** The file is to be loaded as a script into the global scope. */


### PR DESCRIPTION
It was always meant to be extended in the future. The constructor was private, though, which prevent third-parties from extending it. There is no real reason to prevent that, so we actually open it up.

We explicitly validate that `JSEnv`s throw an
`UnsupportedInputException` for `Input`s that they cannot handle, with a new test in the test kit. They were already supposed to do that, but we could not test it before because the tests themselves could not create an unknown `Input`.

---

/cc @tanishiking

With this extension, we will be able to experiment with Wasm inputs in separate repos, until we nail down their semantics for eventual standardization here.