### PR TITLE
Fix a call to `process.exit` in our tests for recent Node.js versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           - nodejsversion: "17"
             scalaversion: "2.12.11"
             project: "scalajs-env-nodejs"
+          - nodejsversion: "25"
+            scalaversion: "2.12.11"
+            project: "scalajs-env-nodejs"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5

--- a/js-envs/src/test/scala/org/scalajs/jsenv/ExternalJSRunTest.scala
+++ b/js-envs/src/test/scala/org/scalajs/jsenv/ExternalJSRunTest.scala
@@ -95,7 +95,7 @@ class ExternalJSRunTest {
     ExternalJSRun.start(List("node"), config) { stdin =>
       val p = new java.io.PrintStream(stdin)
       p.println("""const process = require("process");""");
-      p.println(s"""process.exit(process.env["$name"] !== "$want");""");
+      p.println(s"""process.exit(process.env["$name"] !== "$want" ? 1 : 0);""");
       p.close()
     }
   }


### PR DESCRIPTION
`process.exit` expects a number, not a boolean. Earlier versions of Node.js tolerated booleans, but not anymore.